### PR TITLE
Separate businesslogic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 
 # TypeScript のコンパイル成果物
 dist/
+src/**/*.js
+src/**/*.js.map
 
 # AWS CDK の出力先
 cdk.out/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ src/**/*.js.map
 
 # AWS CDK の出力先
 cdk.out/
+cdk.context.json
 
 # ログファイル
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -5,22 +5,33 @@ AWS Lambdaをデプロイ先として使用します。
 
 ## 構成
 
-- `src/handler.ts`: AWS Lambdaのエントリポイント。LINE Messaging APIからのイベントを処理する関数を定義しています。
-- `src/lineService.ts`: LINE Messaging APIとのインタラクションを管理するサービスクラスを定義しています。メッセージの送信や受信を行うメソッドが含まれています。
-- `src/s3ImageStorage.ts`: S3に画像をアップロードするサービスクラスを定義しています。画像のアップロードやURLの取得を行うメソッドが含まれています。
-- `src/jimpImageProcessor.ts`: Jimpを使用して画像を処理するサービスクラスを定義しています。画像のリサイズやフィルター処理を行うメソッドが含まれています。
-- `src/blobStorage.ts`: Azure Blob Storageに画像をアップロードするサービスクラスを定義しています。画像のアップロードやURLの取得を行うメソッドが含まれています。
-- `src/functions/handler.ts`: Azure Functionsのエントリポイント。LINE Messaging APIからのイベントを処理する関数を定義しています。
-- `src/interfaces`: インターフェースを定義するディレクトリ。型定義を分離して管理します。
-- `bin/line-notify-messenger.ts`: AWS CDKアプリケーションのエントリポイント。スタックを作成し、デプロイするための設定を行います。
-- `lib/lambda-stack.ts`: AWSリソースを定義するCDKスタック。AWS Lambda関数の設定が記述されています。
-- `tsconfig.json`: TypeScriptのコンパイル設定を含むファイル。コンパイラオプションやコンパイル対象のファイルを指定します。
-- `package.json`: npmの設定ファイル。プロジェクトの依存関係やスクリプトをリストしています。
-- `tests/`: テストファイルを格納するディレクトリ。Jestを使用してテストを実行します。
-- `jest.config.js`: Jestの設定ファイル。テストの設定を記述します。
-- `cdk.json`: CDKアプリケーションの設定ファイル。アプリケーションのエントリポイントやスタックの設定を記述します。
-- `bicep/`: Azureリソースを定義するBicepファイルを格納するディレクトリ。
-- `functions/`: Azure Functionsのプロジェクトファイルを格納するディレクトリ。
+- ハンドラー
+  - `src/lambdahandler.ts`: AWS Lambdaのエントリポイント。
+  - `src/functions/handler.ts`: Azure Functionsのエントリポイント。
+- メインロジック
+  - `src/lineNotifyMessengerApp.ts`: LINE Messaging APIからのイベントやHTTPリクエストを処理するロジックを実装しています。
+- 実行環境特有のロジック
+  - `src/lambdaLineNotifyMessenger.ts`: ILineNotifyMessengerを実装したクラス。AWS Lambda固有のロジックを実装しています。
+  - `src/functionsLineNotifyMessenger.ts`: ILineNotifyMessengerを実装したクラス。Azure Functions固有のロジックを実装しています。
+- LINE Messaging API関連
+  - `src/lineService.ts`: LINE Messaging APIとのインタラクションを管理するサービスクラスを定義しています。メッセージの送信や受信を行うメソッドが含まれています。
+- 画像保存
+  - `src/s3ImageStorage.ts`: IImageStorageを実装したクラス。Amazon S3に画像をアップロードするサービスクラスを定義しています。
+  - `src/blobStorage.ts`: IImageStorageを実装したクラス。Azure Blob Storageに画像をアップロードするサービスクラスを定義しています。
+- 画像サイズ変更
+  - `src/jimpImageProcessor.ts`: IImageProcessorを実装したクラス。Jimpを使用して画像を処理するサービスクラスを定義しています。
+- IaC
+  - `bin/line-notify-messenger.ts`: AWS CDKアプリケーションのエントリポイント。スタックを作成し、デプロイするための設定を行います。
+  - `lib/lambda-stack.ts`: AWSリソースを定義するCDKスタック。AWS Lambda関数の設定が記述されています。
+  - `cdk.json`: CDKアプリケーションの設定ファイル。アプリケーションのエントリポイントやスタックの設定を記述します。
+  - `bicep/`: Azureリソースを定義するBicepファイルを格納するディレクトリ。
+- その他
+  - `src/interfaces`: インターフェースを定義するディレクトリ。
+  - `functions/`: Azure Functionsのプロジェクトファイルを格納するディレクトリ。
+  - `tests/`: テストファイルを格納するディレクトリ。Jestを使用してテストを実行します。
+  - `tsconfig.json`: TypeScriptのコンパイル設定を含むファイル。コンパイラオプションやコンパイル対象のファイルを指定します。
+  - `package.json`: npmの設定ファイル。プロジェクトの依存関係やスクリプトをリストしています。
+  - `jest.config.js`: Jestの設定ファイル。テストの設定を記述します。
 
 ## セットアップ手順
 

--- a/src/functionsLineNotifyMessenger.ts
+++ b/src/functionsLineNotifyMessenger.ts
@@ -60,7 +60,7 @@ export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
             formData.imageFile = {
                 'filename': imageFile.name,
                 'contentType': imageFile.type,
-                'content': Buffer.from(imageFile.arrayBuffer())
+                'content': Buffer.from(await imageFile.arrayBuffer())
             }
         } else {
             rawFormData.forEach((value, key) => {

--- a/src/functionsLineNotifyMessenger.ts
+++ b/src/functionsLineNotifyMessenger.ts
@@ -53,8 +53,8 @@ export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
 
     public async getFormDataAsync(): Promise<any> {
         let formData: any = {};
+        const rawFormData = await this.request.formData();
         if (this.getContentType().startsWith('multipart/form-data')) {
-            const rawFormData = await this.request.formData();
             formData.message = rawFormData.get('message');
             const imageFile : any = rawFormData.get('imageFile');
             formData.imageFile = {
@@ -63,8 +63,7 @@ export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
                 'content': Buffer.from(imageFile.arrayBuffer())
             }
         } else {
-            let originalFormData = this.request.formData();
-            originalFormData.forEach((value, key) => {
+            rawFormData.forEach((value, key) => {
                 formData[key] = value;
             });
         }

--- a/src/functionsLineNotifyMessenger.ts
+++ b/src/functionsLineNotifyMessenger.ts
@@ -1,0 +1,77 @@
+import { ILineNotifyMessenger } from './interfaces/lineNotifyMessenger';
+
+export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
+    private request: any;
+
+    constructor(request: any) {
+        this.request = request;
+    }
+
+    public httpInvalidRequestErrorMessage(message: string): any {
+        return {
+            status: 400,
+            body: message
+        };
+    };
+
+    public httpUnAuthorizedErrorMessage (message: string): any {
+        return {
+            status: 401,
+            body: message
+        };    
+    };
+
+    public httpInternalServerErrorMessage(message: string): any {
+        return {
+            status: 500,
+            body: message
+        };
+    };
+
+    public httpOkMessage(message: string): any {
+        return {
+            status: 200,
+            body: message
+        };
+    };
+
+    public getRequestPath(): string {
+        return this.request.url?.split('api/HttpTrigger')[1] || "";
+    }
+
+    public getHttpMethod(): string {
+        return this.request.method;
+    }
+
+    public getContentType(): string {
+        return this.request.headers.get('content-type') || this.request.headers.get('Content-Type') || "";
+    }
+
+    public getBearerToken(): string {
+        return this.request.headers.get('Authorization')?.split('Bearer ')[1] || "";
+    }
+
+    public async getFormDataAsync(): Promise<any> {
+        let formData: any = {};
+        if (this.getContentType().startsWith('multipart/form-data')) {
+            const rawFormData = await this.request.formData();
+            formData.message = rawFormData.get('message');
+            const imageFile : any = rawFormData.get('imageFile');
+            formData.imageFile = {
+                'filename': imageFile.name,
+                'contentType': imageFile.type,
+                'content': Buffer.from(imageFile.arrayBuffer())
+            }
+        } else {
+            let originalFormData = this.request.formData();
+            originalFormData.forEach((value, key) => {
+                formData[key] = value;
+            });
+        }
+        return formData;
+    }
+
+    public async getBodyAsync(): Promise<string> {
+        return await this.request.text();
+    }
+}

--- a/src/functionsLineNotifyMessenger.ts
+++ b/src/functionsLineNotifyMessenger.ts
@@ -7,13 +7,6 @@ export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
         this.request = request;
     }
 
-    public httpInvalidRequestErrorMessage(message: string): any {
-        return {
-            status: 400,
-            body: message
-        };
-    };
-
     public httpUnAuthorizedErrorMessage (message: string): any {
         return {
             status: 401,
@@ -63,7 +56,7 @@ export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
                 'content': Buffer.from(await imageFile.arrayBuffer())
             }
         } else {
-            rawFormData.forEach((value, key) => {
+            rawFormData.forEach((value: FormDataEntryValue, key: string) => {
                 formData[key] = value;
             });
         }

--- a/src/interfaces/lineNotifyMessenger.ts
+++ b/src/interfaces/lineNotifyMessenger.ts
@@ -6,6 +6,6 @@ export interface ILineNotifyMessenger {
     getHttpMethod(): string;
     getContentType(): string;
     getBearerToken(): string;
-    getFormData(): any;
-    getBody(): string;
+    getFormData(): Promise<any>;
+    getBody(): Promise<string>;
 }

--- a/src/interfaces/lineNotifyMessenger.ts
+++ b/src/interfaces/lineNotifyMessenger.ts
@@ -6,6 +6,6 @@ export interface ILineNotifyMessenger {
     getHttpMethod(): string;
     getContentType(): string;
     getBearerToken(): string;
-    getFormData(): Promise<any>;
-    getBody(): Promise<string>;
+    getFormDataAsync(): Promise<any>;
+    getBodyAsync(): Promise<string>;
 }

--- a/src/interfaces/lineNotifyMessenger.ts
+++ b/src/interfaces/lineNotifyMessenger.ts
@@ -1,0 +1,11 @@
+export interface ILineNotifyMessenger {
+    httpUnAuthorizedErrorMessage(message: string): any;
+    httpInternalServerErrorMessage(message: string): any;
+    httpOkMessage(message: string): any;
+    getRequestPath(): string;
+    getHttpMethod(): string;
+    getContentType(): string;
+    getBearerToken(): string;
+    getFormData(): any;
+    getBody(): string;
+}

--- a/src/lambdaLineNotifyMessenger.ts
+++ b/src/lambdaLineNotifyMessenger.ts
@@ -1,0 +1,60 @@
+import { parse } from 'querystring';
+import { ILineNotifyMessenger } from './interfaces/lineNotifyMessenger';
+
+const multipart = require('aws-lambda-multipart-parser');
+
+export class LambdaLineNotifyMessenger implements ILineNotifyMessenger {
+    private event: any;
+
+    constructor(event: any) {
+        this.event = event;
+        if (this.event.isBase64Encoded === true){
+            this.event.body = Buffer.from(this.event.body, 'base64').toString('binary');
+        }
+    }
+
+    public httpUnAuthorizedErrorMessage (message: string): any {
+        return {
+            statusCode: 401,
+            body: JSON.stringify({ message: message }),
+        };
+    };
+
+    public httpInternalServerErrorMessage(message: string): any {
+        return {
+            statusCode: 500,
+            body: JSON.stringify({ message:message }),
+        };
+    };
+
+    public httpOkMessage(message: string): any {
+        return {
+            statusCode: 200,
+            body: JSON.stringify({ message: message }),
+        };
+    };
+
+    public getRequestPath(): string {
+        return this.event.rawPath;
+    }
+
+    public getHttpMethod(): string {
+        return this.event.requestContext?.http?.method || "";
+    }
+
+    public getContentType(): string {
+        return  this.event.headers?.['content-type'] || this.event.headers?.['Content-Type'] || "";
+    }
+
+    public getBearerToken(): string {
+        return this.event.headers?.authorization?.split('Bearer ')[1] || "";
+    }
+
+    public getFormData(): any {
+        return (this.getContentType().startsWith('multipart/form-data')) ? multipart.parse(this.event,true) : parse(this.getBody());
+    }
+
+    public getBody(): string {
+        return this.event.body;
+    }
+}

--- a/src/lambdaLineNotifyMessenger.ts
+++ b/src/lambdaLineNotifyMessenger.ts
@@ -50,11 +50,11 @@ export class LambdaLineNotifyMessenger implements ILineNotifyMessenger {
         return this.event.headers?.authorization?.split('Bearer ')[1] || "";
     }
 
-    public getFormData(): any {
-        return (this.getContentType().startsWith('multipart/form-data')) ? multipart.parse(this.event,true) : parse(this.getBody());
+    public async getFormDataAsync(): Promise<any> {
+        return (this.getContentType().startsWith('multipart/form-data')) ? multipart.parse(this.event,true) : parse(await this.getBodyAsync());
     }
 
-    public getBody(): string {
+    public async getBodyAsync(): Promise<string> {
         return this.event.body;
     }
 }

--- a/src/lambdahandler.ts
+++ b/src/lambdahandler.ts
@@ -1,92 +1,28 @@
-import { parse } from 'querystring';
-import LineService from './lineService';
 import { S3ImageStorage } from './s3ImageStorage';
 import { JimpImageConverter } from './jimpImageConverter';
+import { LambdaLineNotifyMessenger } from './lambdaLineNotifyMessenger';
+import { LineNotifyMessengerApp } from './lineNotifyMessengerApp';
 
 const multipart = require('aws-lambda-multipart-parser');
-
-const httpUnAuthorizedErrorMessage = (message: string) => {
-    return {
-        statusCode: 401,
-        body: JSON.stringify({ message: message }),
-    };
-};
-
-const httpInternalServerErrorMessage = (message: string) => {
-    return {
-        statusCode: 500,
-        body: JSON.stringify({ message:message }),
-    };
-};
-
-const httpOkMessage = (message: string) => {
-    return {
-        statusCode: 200,
-        body: JSON.stringify({ message: message }),
-    };
-};
-
-const isNotifyServiceRequest = (path: string,method: string, contentType: string): boolean => {
-    if(path === '/notify' && method === 'POST' && ( contentType === 'application/x-www-form-urlencoded' || contentType.startsWith('multipart/form-data'))) {
-        return true;
-    }
-    return false;
-};
-
-const sendBroadcastMessage = async (lineService: LineService,formData: any) => {
-    await lineService.broadcastMessage(formData);
-};
-
-const replyDefaultMessage = async (lineService: LineService, body: any) => {
-    const replyToken = body.events[0].replyToken;
-    await lineService.replyMessage(replyToken, 'お送り頂いたメッセージはどこにも送られないのでご注意ください');
-};
 
 export const handler = async (event: any) => {
     console.log('Received event:', JSON.stringify(event, null, 2));
 
+    const messenger = new LambdaLineNotifyMessenger(event);
+
     const lineChannelAccessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN;
     if (!lineChannelAccessToken) {
-        return httpInternalServerErrorMessage('LINE_CHANNEL_ACCESS_TOKEN is not set');
+        return messenger.httpInternalServerErrorMessage('LINE_CHANNEL_ACCESS_TOKEN is not set');
     }
 
-    /* notify event */
-    const contentType = event.headers?.['content-type'] || event.headers?.['Content-Type'];
     const bucketName = process.env.BUCKET_NAME;
     const s3Region = process.env.S3_REGION;
 
     if (!bucketName || !s3Region) {
-        return httpInternalServerErrorMessage('BUCKET_NAME or S3_REGION is not set');
+        return messenger.httpInternalServerErrorMessage('BUCKET_NAME or S3_REGION is not set');
     }
 
-    const lineService = new LineService(lineChannelAccessToken, new S3ImageStorage(bucketName, s3Region), new JimpImageConverter());
+    const app = new LineNotifyMessengerApp(messenger, lineChannelAccessToken, new S3ImageStorage(bucketName, s3Region), new JimpImageConverter());
 
-    if (event.isBase64Encoded === true){
-        event.body = Buffer.from(event.body, 'base64').toString('binary');
-    }
-
-    if(isNotifyServiceRequest(event.rawPath, event.requestContext?.http?.method, contentType)) {
-        const bearerToken = event.headers?.authorization?.split('Bearer ')[1];
-
-        if (!bearerToken || bearerToken !== process.env.AUTHORIZATION_TOKEN) {
-            return httpUnAuthorizedErrorMessage('Invalid authorization token');
-        }
-
-        const formData = (contentType.startsWith('multipart/form-data')) ? multipart.parse(event,true) : parse(event.body);
-
-        await sendBroadcastMessage(lineService,formData);
-        return httpOkMessage('Success Notify');
-    }
-
-    const body = JSON.parse(event.body);
-
-    /* health check from LINE */
-    if(body.events.length === 0) {
-        return httpOkMessage('No events');
-    }
-
-    /* reply default message */
-    await replyDefaultMessage(lineService, body);
-
-    return httpOkMessage('Success');
+    return await app.processRequest();
 };

--- a/src/lineNotifyMessengerApp.ts
+++ b/src/lineNotifyMessengerApp.ts
@@ -1,0 +1,62 @@
+import { ILineNotifyMessenger } from './interfaces/lineNotifyMessenger';
+import { IImageStorage } from './interfaces/imageStorage';
+import { IImageConverter } from './interfaces/imageConverter';
+import LineService from './lineService';
+
+export class LineNotifyMessengerApp {
+    private messenger: ILineNotifyMessenger;
+    private lineService: LineService;
+
+    constructor  (messenger:ILineNotifyMessenger, lineChannelAccessToken: string,imageStorage: IImageStorage, imageConverter: IImageConverter) {
+        this.messenger = messenger;
+        this.lineService = new LineService(lineChannelAccessToken, imageStorage, imageConverter);
+    }
+
+    private isNotifyServiceRequest = () => {
+        const path = this.messenger.getRequestPath();
+        const method = this.messenger.getHttpMethod();
+        const contentType = this.messenger.getContentType();
+
+        if(path === '/notify' && method === 'POST' && ( contentType === 'application/x-www-form-urlencoded' || contentType.startsWith('multipart/form-data'))) {
+            return true;
+        }
+        return false;
+    };
+    
+    private sendBroadcastMessage = async (formData: any) => {
+        await this.lineService.broadcastMessage(formData);
+    };
+    
+    private replyDefaultMessage = async (body: any) => {
+        const replyToken = body.events[0].replyToken;
+        await this.lineService.replyMessage(replyToken, 'お送り頂いたメッセージはどこにも送られないのでご注意ください');
+    };
+    
+    async processRequest() {
+        if(this.isNotifyServiceRequest()) {
+            const bearerToken = this.messenger.getBearerToken();
+    
+            if (!bearerToken || bearerToken !== process.env.AUTHORIZATION_TOKEN) {
+                return this.messenger.httpUnAuthorizedErrorMessage('Invalid authorization token');
+            }
+    
+            const formData = this.messenger.getFormData();
+    
+            await this.sendBroadcastMessage(formData);
+            return this.messenger.httpOkMessage('Success Notify');
+        }
+    
+        const body = JSON.parse(this.messenger.getBody());
+    
+        /* health check from LINE */
+        if(body.events.length === 0) {
+            return this.messenger.httpOkMessage('No events');
+        }
+    
+        /* reply default message */
+        await this.replyDefaultMessage(body);
+    
+        return this.messenger.httpOkMessage('Success');
+    };
+        
+}

--- a/src/lineNotifyMessengerApp.ts
+++ b/src/lineNotifyMessengerApp.ts
@@ -40,13 +40,13 @@ export class LineNotifyMessengerApp {
                 return this.messenger.httpUnAuthorizedErrorMessage('Invalid authorization token');
             }
     
-            const formData = this.messenger.getFormData();
+            const formData = await this.messenger.getFormDataAsync();
     
             await this.sendBroadcastMessage(formData);
             return this.messenger.httpOkMessage('Success Notify');
         }
     
-        const body = JSON.parse(this.messenger.getBody());
+        const body = JSON.parse(await this.messenger.getBodyAsync());
     
         /* health check from LINE */
         if(body.events.length === 0) {


### PR DESCRIPTION
This pull request refactors the handling of HTTP and Lambda requests for the Line Notify Messenger application. The main changes include the introduction of new classes to encapsulate request handling logic, the removal of redundant code, and the centralization of common functionalities.

Refactoring and Code Simplification:

* [`src/functions/HttpTrigger.ts`](diffhunk://#diff-aab42234b9141986d578d048c59cd9cda32ed4591b8848720f7ed47615b3960fL2-R26): Replaced inline request handling logic with the `FunctionsLineNotifyMessenger` and `LineNotifyMessengerApp` classes to streamline the code and reduce redundancy.
* [`src/lambdahandler.ts`](diffhunk://#diff-b628f8758da0d11518ffeb3fe1e198d68ea6129d24f1d5d2341838d68993ccb8L1-R27): Similar to the HTTP trigger, replaced the existing request handling logic with the `LambdaLineNotifyMessenger` and `LineNotifyMessengerApp` classes.

New Classes and Interfaces:

* [`src/functionsLineNotifyMessenger.ts`](diffhunk://#diff-c0ee72b837a6e6b7b13eb9f39d4feb8457515fac17a001ab6fcc08b07850beb7R1-R69): Introduced the `FunctionsLineNotifyMessenger` class to handle HTTP-specific request logic.
* [`src/lambdaLineNotifyMessenger.ts`](diffhunk://#diff-ad8776f1cb24efc6ecbaccf25302c6df1bc824af9b1c77facaac1dd100830f7bR1-R60): Added the `LambdaLineNotifyMessenger` class to handle Lambda-specific request logic.
* [`src/interfaces/lineNotifyMessenger.ts`](diffhunk://#diff-a9770964e8b041202228de722efb5fa1a6f1d4ccf5036099c17d9d9ce369b4b3R1-R11): Defined the `ILineNotifyMessenger` interface to standardize the request handling methods across different environments.
* [`src/lineNotifyMessengerApp.ts`](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0R1-R62): Created the `LineNotifyMessengerApp` class to encapsulate the main application logic, making it reusable across different request handlers.

close #10 