### PR TITLE
[modify] HTTPメソッドとヘッダーの取得メソッドをリファクタリングし、命名を統一

### DIFF
--- a/src/functionsLineNotifyMessenger.ts
+++ b/src/functionsLineNotifyMessenger.ts
@@ -14,7 +14,7 @@ export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
         };    
     };
 
-    public getRequestPath(): string {
+    public getHttpRequestPath(): string {
         return this.request.url?.split('api/HttpTrigger')[1] || "";
     }
 
@@ -22,18 +22,14 @@ export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
         return this.request.method;
     }
 
-    public getContentType(): string {
-        return this.request.headers.get('content-type') || this.request.headers.get('Content-Type') || "";
+    public getHttpHeader(name: string): string {
+        return this.request.headers.get(name) || this.request.headers.get(name.toLowerCase()) || "";
     }
 
-    public getBearerToken(): string {
-        return this.request.headers.get('Authorization')?.split('Bearer ')[1] || "";
-    }
-
-    public async getFormDataAsync(): Promise<any> {
+    public async getHttpFormDataAsync(): Promise<any> {
         let formData: any = {};
         const rawFormData = await this.request.formData();
-        if (this.getContentType().startsWith('multipart/form-data')) {
+        if (this.getHttpHeader('Content-Type').startsWith('multipart/form-data')) {
             formData.message = rawFormData.get('message');
             const imageFile : any = rawFormData.get('imageFile');
             formData.imageFile = {
@@ -50,7 +46,7 @@ export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
         return formData;
     }
 
-    public async getBodyAsync(): Promise<string> {
+    public async getHttpBodyAsync(): Promise<string> {
         return await this.request.text();
     }
 }

--- a/src/interfaces/lineNotifyMessenger.ts
+++ b/src/interfaces/lineNotifyMessenger.ts
@@ -1,9 +1,8 @@
 export interface ILineNotifyMessenger {
     buildHttpResponse(status: number, body: string): any;
-    getRequestPath(): string;
+    getHttpRequestPath(): string;
     getHttpMethod(): string;
-    getContentType(): string;
-    getBearerToken(): string;
-    getFormDataAsync(): Promise<any>;
-    getBodyAsync(): Promise<string>;
+    getHttpHeader(name: string): string;
+    getHttpFormDataAsync(): Promise<any>;
+    getHttpBodyAsync(): Promise<string>;
 }

--- a/src/lambdaLineNotifyMessenger.ts
+++ b/src/lambdaLineNotifyMessenger.ts
@@ -20,7 +20,7 @@ export class LambdaLineNotifyMessenger implements ILineNotifyMessenger {
         };
     };
 
-    public getRequestPath(): string {
+    public getHttpRequestPath(): string {
         return this.event.rawPath;
     }
 
@@ -28,19 +28,14 @@ export class LambdaLineNotifyMessenger implements ILineNotifyMessenger {
         return this.event.requestContext?.http?.method || "";
     }
 
-    public getContentType(): string {
-        return  this.event.headers?.['content-type'] || this.event.headers?.['Content-Type'] || "";
+    public getHttpHeader(name: string): string {
+        return this.event.headers?.[name] || this.event.headers?.[name.toLowerCase()] || "";
+    }
+    public async getHttpFormDataAsync(): Promise<any> {
+        return (this.getHttpHeader('Content-Type').startsWith('multipart/form-data')) ? multipart.parse(this.event,true) : parse(await this.getHttpBodyAsync());
     }
 
-    public getBearerToken(): string {
-        return this.event.headers?.authorization?.split('Bearer ')[1] || "";
-    }
-
-    public async getFormDataAsync(): Promise<any> {
-        return (this.getContentType().startsWith('multipart/form-data')) ? multipart.parse(this.event,true) : parse(await this.getBodyAsync());
-    }
-
-    public async getBodyAsync(): Promise<string> {
+    public async getHttpBodyAsync(): Promise<string> {
         return this.event.body;
     }
 }


### PR DESCRIPTION
This pull request includes several changes to standardize method names and improve the consistency of the codebase. The most important changes include renaming methods to follow a consistent naming convention and updating references to these methods across various files.

Method name standardization:

* [`src/functionsLineNotifyMessenger.ts`](diffhunk://#diff-c0ee72b837a6e6b7b13eb9f39d4feb8457515fac17a001ab6fcc08b07850beb7L17-R32): Renamed methods to include "Http" in their names for clarity, such as `getRequestPath` to `getHttpRequestPath`, `getContentType` to `getHttpHeader`, and `getBodyAsync` to `getHttpBodyAsync`. [[1]](diffhunk://#diff-c0ee72b837a6e6b7b13eb9f39d4feb8457515fac17a001ab6fcc08b07850beb7L17-R32) [[2]](diffhunk://#diff-c0ee72b837a6e6b7b13eb9f39d4feb8457515fac17a001ab6fcc08b07850beb7L53-R49)
* [`src/interfaces/lineNotifyMessenger.ts`](diffhunk://#diff-a9770964e8b041202228de722efb5fa1a6f1d4ccf5036099c17d9d9ce369b4b3L3-R7): Updated interface method names to match the new naming convention, such as `getRequestPath` to `getHttpRequestPath` and `getBodyAsync` to `getHttpBodyAsync`.
* [`src/lambdaLineNotifyMessenger.ts`](diffhunk://#diff-ad8776f1cb24efc6ecbaccf25302c6df1bc824af9b1c77facaac1dd100830f7bL23-R38): Renamed methods to include "Http" in their names for consistency, such as `getRequestPath` to `getHttpRequestPath`, `getContentType` to `getHttpHeader`, and `getBodyAsync` to `getHttpBodyAsync`.
* [`src/lineNotifyMessengerApp.ts`](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0R27-R34): Updated method calls to use the new standardized method names, such as `getRequestPath` to `getHttpRequestPath`, `getContentType` to `getHttpHeader`, and `getBodyAsync` to `getHttpBodyAsync`. Added a new method `getBearerToken` to encapsulate the logic for extracting the bearer token from headers. [[1]](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0R27-R34) [[2]](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0L49-R65)

close #19 