### PR TITLE
[modify] sendMode取得をストラテジパターンにリファクタ

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ AWS LambdaまたはAzure Functionsをデプロイ先として使用します。
 - グループID保存
   - `src/dynamoGroupRepository.ts`: IGroupRepositoryを実装したクラス。Amazon DynamoDBにグループIDを保存するリポジトリクラスを定義しています。
   - `src/tableStorageGroupRepository.ts`: IGroupRepositoryを実装したクラス。Azure Table StorageにグループIDを保存するリポジトリクラスを定義しています。
+- 送信モード
+  - `src/sendModeStrategy.ts`: ISendModeStrategyを実装したクラス。送信モードを取得する手段をストラテジークラスを定義しています。環境変数から取得するEnvironmentSendModeStrategyが実装されていて、これがデフォルトで利用されます。他の手段で取得する場合はここで実装し、`lineNotifyMessengerApp`クラスのコンストラクタでDIします。
 - IaC
   - `bin/line-notify-messenger.ts`: AWS CDKアプリケーションのエントリポイント。スタックを作成し、デプロイするための設定を行います。
   - `lib/lambda-stack.ts`: AWSリソースを定義するCDKスタック。AWS Lambda関数の設定が記述されています。

--- a/src/interfaces/sendModeStrategy.ts
+++ b/src/interfaces/sendModeStrategy.ts
@@ -1,0 +1,9 @@
+export enum SendMode {
+    broadcast = 'broadcast',
+    group = 'group',
+    all = 'all'
+}
+
+export interface ISendModeStrategy {
+    getSendMode(): SendMode;
+}

--- a/src/sendModeStrategy.ts
+++ b/src/sendModeStrategy.ts
@@ -1,0 +1,16 @@
+import { SendMode, ISendModeStrategy } from './interfaces/sendModeStrategy';
+export class DefaultSendModeStrategy implements ISendModeStrategy {
+    getSendMode(): SendMode {
+        return SendMode.broadcast;
+    }
+}
+
+export class EnvironmentSendModeStrategy implements ISendModeStrategy {
+    getSendMode(): SendMode {
+        const mode = process.env.SEND_MODE || SendMode.broadcast;
+        if (!Object.values(SendMode).includes(mode as SendMode)) {
+            return SendMode.broadcast;
+        }
+        return mode as SendMode;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new strategy pattern for handling send modes in the `LineNotifyMessengerApp` class. The changes include the addition of new interfaces and classes to support this pattern, and the refactoring of existing code to utilize these new components.

### Strategy Pattern Implementation:

* [`src/interfaces/sendModeStrategy.ts`](diffhunk://#diff-19b6e43b363f8a4c936d513a435b15212dc5f9b45a06ecaf8e120c7fa82cbde0R1-R9): Added `SendMode` enum and `ISendModeStrategy` interface to define the contract for send mode strategies.
* [`src/sendModeStrategy.ts`](diffhunk://#diff-8ed5b088a3bf88181c4471076d95c652a10581bb9dc5ec8ae1341cb762b77ffcR1-R16): Implemented `DefaultSendModeStrategy` and `EnvironmentSendModeStrategy` classes, which provide different methods to determine the send mode.

### Refactoring:

* [`src/lineNotifyMessengerApp.ts`](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0L7-R83): Refactored `LineNotifyMessengerApp` class to use the `ISendModeStrategy` interface. The constructor now accepts an `ISendModeStrategy` parameter, defaulting to `EnvironmentSendModeStrategy`. Removed the old `getSendMode` method and replaced it with the strategy pattern. [[1]](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0L7-R83) [[2]](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0L99-R110) [[3]](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0L132-R138)

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R27): Updated documentation to include information about the new `sendModeStrategy` and how to implement different strategies.