### PR TITLE
[modify] requestHandlerを分離

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -1,0 +1,34 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+import { ILineNotifyMessenger } from './interfaces/lineNotifyMessenger';
+
+export class RequestHandler {
+    private messenger: ILineNotifyMessenger;
+
+    constructor(messenger: ILineNotifyMessenger) {
+        this.messenger = messenger;
+    }
+
+    getBearerToken(): string {
+        return this.messenger.getHttpHeader('Authorization').split('Bearer ')[1] || '';
+    }
+
+    isNotifyServiceRequest(): boolean {
+        const path = this.messenger.getHttpRequestPath();
+        const method = this.messenger.getHttpMethod();
+        const contentType = this.messenger.getHttpHeader('Content-Type');
+
+        return (
+            path === '/notify' &&
+            method === 'POST' &&
+            (contentType === 'application/x-www-form-urlencoded' || contentType.startsWith('multipart/form-data'))
+        );
+    }
+
+    async getRequestBody(): Promise<any> {
+        return JSON.parse(await this.messenger.getHttpBodyAsync());
+    }
+
+    async getFormData(): Promise<any> {
+        return this.messenger.getHttpFormDataAsync();
+    }
+}


### PR DESCRIPTION
This pull request refactors the `LineNotifyMessengerApp` class to delegate request handling to a new `RequestHandler` class. The main changes include the creation of the `RequestHandler` class and the removal of several methods from `LineNotifyMessengerApp`, which are now handled by `RequestHandler`.

Refactoring to delegate request handling:

* [`src/lineNotifyMessengerApp.ts`](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0R9-R16): Added import for `RequestHandler` and initialized it in the constructor. [[1]](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0R9-R16) [[2]](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0R30)
* [`src/lineNotifyMessengerApp.ts`](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0L42-L60): Removed methods `getBearerToken`, `isNotifyServiceRequest`, `getRequestBody`, and `getFormData` from `LineNotifyMessengerApp`. These methods are now part of `RequestHandler`. [[1]](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0L42-L60) [[2]](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0L115-R112)
* [`src/lineNotifyMessengerApp.ts`](diffhunk://#diff-de82b3186b5ff6a207a1470ab3bfbe148916640e7b92b1c7f58018988e5305d0L115-R112): Updated `processRequest` method to use `RequestHandler` for request handling logic.
* [`src/requestHandler.ts`](diffhunk://#diff-7a164b02f2f7e443958e5903e85c36757e57e5b0ca7873bef5ba04d4df6efa2bR1-R34): Added new `RequestHandler` class to encapsulate request handling logic, including methods `getBearerToken`, `isNotifyServiceRequest`, `getRequestBody`, and `getFormData`.

These changes improve the separation of concerns by moving request handling logic out of `LineNotifyMessengerApp` and into a dedicated `RequestHandler` class.