### PR TITLE
[modify] LineNotifyMessengerクラスをリネーム

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,13 @@
 
 - AWS Lambda/Azure Functions以外の環境向けの実装を追加する場合、以下の手順に従って実装を追加してください。
   - 実行環境特有のロジック
-    - 主にHTTPの入出力など環境特有の処理について、`src/interfaces/lineNotifyMessenger.ts`を実装したクラスを作成してください。
+    - 主にHTTPの入出力など環境特有の処理について、`src/interfaces/httpRequestHandler.ts`を実装したクラスを作成してください。
   - 画像保存
     - 画像を保存するサービスとして、`src/interfaces/imageStorage.ts`を実装したクラスを作成してください。
   - グループID保存
     - グループIDを保存するサービスとして`src/interfaces/groupRepository.ts`を実装したクラスを作成してください。
   - エンドポイントの作成
-    - `src/lambdahandler.ts`や`src/functions/HttpTrigger.ts`を参考に、環境固有のエンドポイントを作成してください。基本的には必要な環境変数をチェックしたら、ILineNotifyMessenger/IImageStorage/IGroupRepositoryを実装したクラスをDIして`LineNotifyMessengerApp`のインスタンスを作成し、`processRequest()`メソッドを呼んでください。
+    - `src/lambdahandler.ts`や`src/functions/HttpTrigger.ts`を参考に、環境固有のエンドポイントを作成してください。基本的には必要な環境変数をチェックしたら、IHttpRequestHandler/IImageStorage/IGroupRepositoryを実装したクラスをDIして`LineNotifyMessengerApp`のインスタンスを作成し、`processRequest()`メソッドを呼んでください。
   - IaCとCI/CDの追加
     - 可能であれば環境を構築するためのIaCならびにデプロイするためのワークフローファイルを追加してください。難しい場合は、READMEに手動でのデプロイ手順を追加してください。
   - テストの追加

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ AWS LambdaまたはAzure Functionsをデプロイ先として使用します。
 
 - エントリポイント
   - `src/lambdahandler.ts`: AWS Lambdaのエントリポイント。
-  - `src/functions/handler.ts`: Azure Functionsのエントリポイント。
+  - `src/functions/HttpTrigger.ts`: Azure Functionsのエントリポイント。
 - メインロジック
-  - `src/core/lineNotifyMessengerApp.ts`: LINE Messaging APIからのイベントやHTTPリクエストを処理するロジックを実装しています。
+  - `src/core/LineNotifyMessengerApp.ts`: LINE Messaging APIからのイベントやHTTPリクエストを処理するロジックを実装しています。
   - `src/services/groupService.ts`: グループIDを管理するサービスクラスを定義しています。グループIDの保存や取得を行うメソッドが含まれています。
   - `src/services/httpResponseService.ts`: HTTPレスポンスを生成するサービスクラスを定義しています。HTTPステータスコードやメッセージを指定してレスポンスを生成するメソッドが含まれています。
   - `src/services/messageService.ts`: メッセージ送信のサービスクラスを定義しています。実際のメッセージの生成や送信を行うメソッドは`lineService`クラスに含まれます。
   - `src/handlers/requestHandler.ts`: HTTPリクエストを処理するクラスを定義しています。
 - 実行環境特有のロジック
-  - `src/core/lambdaLineNotifyMessenger.ts`: ILineNotifyMessengerを実装したクラス。AWS Lambda固有のロジックを実装しています。
-  - `src/core/functionsLineNotifyMessenger.ts`: ILineNotifyMessengerを実装したクラス。Azure Functions固有のロジックを実装しています。
+  - `src/handlers/lambdaHttpRequestHandler.ts`: IHttpRequestHandlerを実装したクラス。AWS Lambda固有のロジックを実装しています。
+  - `src/handlers/functionsHttpRequestHandler.ts`: IHttpRequestHandlerを実装したクラス。Azure Functions固有のロジックを実装しています。
 - LINE Messaging API関連
   - `src/services/lineService.ts`: LINE Messaging APIとのインタラクションを管理するサービスクラスを定義しています。メッセージの送信や受信を行うメソッドが含まれています。
 - 画像保存
@@ -28,7 +28,7 @@ AWS LambdaまたはAzure Functionsをデプロイ先として使用します。
   - `src/repositories/dynamoGroupRepository.ts`: IGroupRepositoryを実装したクラス。Amazon DynamoDBにグループIDを保存するリポジトリクラスを定義しています。
   - `src/repositories/tableStorageGroupRepository.ts`: IGroupRepositoryを実装したクラス。Azure Table StorageにグループIDを保存するリポジトリクラスを定義しています。
 - 送信モード
-  - `src/strategies/sendModeStrategy.ts`: ISendModeStrategyを実装したクラス。送信モードを取得する手段をストラテジークラスを定義しています。環境変数から取得するEnvironmentSendModeStrategyが実装されていて、これがデフォルトで利用されます。他の手段で取得する場合はここで実装し、`lineNotifyMessengerApp`クラスのコンストラクタでDIします。
+  - `src/strategies/sendModeStrategy.ts`: ISendModeStrategyを実装したクラス。送信モードを取得する手段をストラテジークラスを定義しています。環境変数から取得するEnvironmentSendModeStrategyが実装されていて、これがデフォルトで利用されます。他の手段で取得する場合はここで実装し、`LineNotifyMessengerApp`クラスのコンストラクタでDIします。
 - IaC
   - `bin/line-notify-messenger.ts`: AWS CDKアプリケーションのエントリポイント。スタックを作成し、デプロイするための設定を行います。
   - `lib/lambda-stack.ts`: AWSリソースを定義するCDKスタック。AWS Lambda関数の設定が記述されています。

--- a/src/functions/HttpTrigger.ts
+++ b/src/functions/HttpTrigger.ts
@@ -3,14 +3,14 @@ import { container } from 'tsyringe';
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
 import { BlobImageStorage } from "@repositories/blobImageStorage";
 import { JimpImageConverter } from "@utils/jimpImageConverter";
-import { FunctionsLineNotifyMessenger } from "@core/functionsLineNotifyMessenger";
+import { FunctionsHttpRequestHandler } from "@handlers/functionsHttpRequestHandler";
 import { LineNotifyMessengerApp } from "@core/lineNotifyMessengerApp";
-import { FunctionsHttpResponse } from "@interfaces/lineNotifyMessenger";
+import { AzureFunctionsHttpResponse } from "@interfaces/httpRequestHandler";
 import { TableStorageGroupRepository } from "@repositories/tableStorageGroupRepository";
 import { IImageStorage } from '@interfaces/imageStorage';
 import { IImageConverter } from '@interfaces/imageConverter';
 import { IGroupRepository } from '@interfaces/groupRepository';
-import { ILineNotifyMessenger } from '@interfaces/lineNotifyMessenger';
+import { IHttpRequestHandler } from '@interfaces/httpRequestHandler';
 import { ISendModeStrategy } from '@interfaces/sendModeStrategy';
 import { EnvironmentSendModeStrategy } from '@strategies/sendModeStrategy';
 import LineService from '@services/lineService';
@@ -53,14 +53,14 @@ export async function HttpTrigger(request: HttpRequest, context: InvocationConte
     container.registerInstance<IImageStorage>('IImageStorage', new BlobImageStorage(blobConnectionString, blobName));
     container.register<IImageConverter>('IImageConverter', JimpImageConverter);
     container.registerInstance<IGroupRepository>('IGroupRepository', new TableStorageGroupRepository(tableConnectionString, tableName));
-    container.registerInstance<ILineNotifyMessenger>('ILineNotifyMessenger', new FunctionsLineNotifyMessenger(request));
+    container.registerInstance<IHttpRequestHandler>('IHttpRequestHandler', new FunctionsHttpRequestHandler(request));
     container.register<ISendModeStrategy>('ISendModeStrategy', { useClass: EnvironmentSendModeStrategy });
     container.register('LineService', { useClass: LineService });
 
     // TsyringeでLineNotifyMessengerAppを解決
     const app = container.resolve(LineNotifyMessengerApp);
 
-    return await app.processRequest() as FunctionsHttpResponse;
+    return await app.processRequest() as AzureFunctionsHttpResponse;
 }
 
 /**

--- a/src/handlers/functionsHttpRequestHandler.ts
+++ b/src/handlers/functionsHttpRequestHandler.ts
@@ -1,20 +1,20 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
-import { ILineNotifyMessenger, FunctionsHttpResponse } from '@interfaces/lineNotifyMessenger';
+import { IHttpRequestHandler , AzureFunctionsHttpResponse } from '@interfaces/httpRequestHandler';
 
 /**
  * Azure Functions環境用のLINE Notify Messengerの実装クラス
  * HTTP要求を処理し、LINE Notifyに必要なデータを抽出するためのメソッドを提供します
  * 
  * このクラスはHTTPリクエストオブジェクトをラップし、LINE Notifyに関連する
- * データ処理とレスポンス生成の責務を担います。ILineNotifyMessengerインターフェースを実装し、
+ * データ処理とレスポンス生成の責務を担います。IHttpRequestHandlerインターフェースを実装し、
  * Azure Functions固有の実装を提供します。
  */
-export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
+export class FunctionsHttpRequestHandler implements IHttpRequestHandler {
     /** Azure Functionsから受け取ったHTTPリクエストオブジェクト */
     private request: any;
 
     /**
-     * FunctionsLineNotifyMessengerのコンストラクタ
+     * FunctionsHttpRequestHandlerのコンストラクタ
      * @param request - Azure Functionsから受け取ったHTTPリクエストオブジェクト
      */
     constructor(request: any) {
@@ -27,8 +27,8 @@ export class FunctionsLineNotifyMessenger implements ILineNotifyMessenger {
      * @param message - レスポンスメッセージ
      * @returns 生成されたHTTP応答オブジェクト
      */
-    public buildHttpResponse(status: number, message: string): FunctionsHttpResponse {
-        return new FunctionsHttpResponse(status, message);
+    public buildHttpResponse(status: number, message: string): AzureFunctionsHttpResponse {
+        return new AzureFunctionsHttpResponse(status, message);
     }
 
     /**

--- a/src/handlers/lambdaHttpRequestHandler.ts
+++ b/src/handlers/lambdaHttpRequestHandler.ts
@@ -1,18 +1,18 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import { parse } from 'querystring';
-import { ILineNotifyMessenger, LambdaHttpResponse } from '@interfaces/lineNotifyMessenger';
+import { IHttpRequestHandler, AwsLambdaHttpResponse } from '@interfaces/httpRequestHandler';
 import * as multipart from 'aws-lambda-multipart-parser';
 
 /**
  * AWS Lambda環境用のLINE Notify Messengerの実装クラス
  * HTTP要求を処理し、LINE Notifyに必要なデータを抽出するためのメソッドを提供します
  */
-export class LambdaLineNotifyMessenger implements ILineNotifyMessenger {
+export class LambdaHttpRequestHandler implements IHttpRequestHandler {
     /** AWS Lambdaから受け取ったイベントオブジェクト */
     private event: any;
 
     /**
-     * LambdaLineNotifyMessengerのコンストラクタ
+     * LambdaHttpRequestHandlerのコンストラクタ
      * @param event - AWS Lambdaから受け取ったイベントオブジェクト
      */
     constructor(event: any) {
@@ -28,8 +28,8 @@ export class LambdaLineNotifyMessenger implements ILineNotifyMessenger {
      * @param message - レスポンスメッセージ
      * @returns 生成されたHTTP応答オブジェクト
      */
-    public buildHttpResponse (status: number, message: string): LambdaHttpResponse {
-        return new LambdaHttpResponse(status,JSON.stringify({ message: message }));
+    public buildHttpResponse (status: number, message: string): AwsLambdaHttpResponse {
+        return new AwsLambdaHttpResponse(status,JSON.stringify({ message: message }));
     }
 
     /**

--- a/src/handlers/requestHandler.ts
+++ b/src/handlers/requestHandler.ts
@@ -1,25 +1,25 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import 'reflect-metadata';
-import { ILineNotifyMessenger } from '@interfaces/lineNotifyMessenger';
+import { IHttpRequestHandler } from '@interfaces/httpRequestHandler';
 import { inject, injectable } from 'tsyringe';
 
 /**
  * HTTPリクエスト処理を担当するハンドラークラス
- * ILineNotifyMessengerを利用してリクエストの解析と必要なデータの抽出を行います
+ * IHttpRequestHandlerを利用してリクエストの解析と必要なデータの抽出を行います
  */
 @injectable()
 export class RequestHandler {
-    /** HTTPリクエスト/レスポンス処理を担当するメッセンジャー */
-    private messenger: ILineNotifyMessenger;
+    /** HTTPリクエスト/レスポンス処理を担当するハンドラー */
+    private handler: IHttpRequestHandler;
 
     /**
      * RequestHandlerのコンストラクタ
-     * @param messenger - HTTPリクエスト/レスポンス処理用メッセンジャー
+     * @param handler - HTTPリクエスト/レスポンス処理用ハンドラー
      */
     constructor(
-        @inject('ILineNotifyMessenger') messenger: ILineNotifyMessenger,
+        @inject('IHttpRequestHandler') handler: IHttpRequestHandler,
     ) {
-        this.messenger = messenger;
+        this.handler = handler;
     }
 
     /**
@@ -27,7 +27,7 @@ export class RequestHandler {
      * @returns Bearerトークン（存在しない場合は空文字列）
      */
     getBearerToken(): string {
-        return this.messenger.getHttpHeader('Authorization').split('Bearer ')[1] || '';
+        return this.handler.getHttpHeader('Authorization').split('Bearer ')[1] || '';
     }
 
     /**
@@ -39,9 +39,9 @@ export class RequestHandler {
      * @returns 通知サービス向けの場合はtrue、そうでない場合はfalse
      */
     isNotifyServiceRequest(): boolean {
-        const path = this.messenger.getHttpRequestPath();
-        const method = this.messenger.getHttpMethod();
-        const contentType = this.messenger.getHttpHeader('Content-Type');
+        const path = this.handler.getHttpRequestPath();
+        const method = this.handler.getHttpMethod();
+        const contentType = this.handler.getHttpHeader('Content-Type');
 
         return (
             path === '/notify' &&
@@ -55,15 +55,15 @@ export class RequestHandler {
      * @returns 解析されたJSONオブジェクト
      */
     async getRequestBody(): Promise<any> {
-        return JSON.parse(await this.messenger.getHttpBodyAsync());
+        return JSON.parse(await this.handler.getHttpBodyAsync());
     }
 
     /**
      * フォームデータを取得して処理します
-     * 実際の処理はILineNotifyMessengerの実装に委譲されます
+     * 実際の処理はIHttpRequestHandlerの実装に委譲されます
      * @returns 処理されたフォームデータ
      */
     async getFormData(): Promise<any> {
-        return this.messenger.getHttpFormDataAsync();
+        return this.handler.getHttpFormDataAsync();
     }
 }

--- a/src/interfaces/httpRequestHandler.ts
+++ b/src/interfaces/httpRequestHandler.ts
@@ -4,14 +4,14 @@
  * Azure Functions用のHTTPレスポンスクラス
  * Azure Functions環境でHTTPレスポンスを表現します
  */
-export class FunctionsHttpResponse {
+export class AzureFunctionsHttpResponse {
     /** HTTPステータスコード */
     public status: number;
     /** レスポンスボディの内容 */
     public body: string;
 
     /**
-     * FunctionsHttpResponseのコンストラクタ
+     * AzureFunctionsHttpResponseのコンストラクタ
      * @param status - HTTPステータスコード
      * @param body - レスポンスボディの内容
      */
@@ -25,14 +25,14 @@ export class FunctionsHttpResponse {
  * AWS Lambda用のHTTPレスポンスクラス
  * API Gateway + Lambda環境でHTTPレスポンスを表現します
  */
-export class LambdaHttpResponse {
+export class AwsLambdaHttpResponse {
     /** HTTPステータスコード */
     public statusCode: number;
     /** レスポンスボディの内容 */
     public body: string;
 
     /**
-     * LambdaHttpResponseのコンストラクタ
+     * AwsLambdaHttpResponseのコンストラクタ
      * @param statusCode - HTTPステータスコード
      * @param body - レスポンスボディの内容
      */
@@ -47,14 +47,14 @@ export class LambdaHttpResponse {
  * 異なる実行環境（Azure Functions、AWS Lambda）間で
  * HTTPリクエスト処理を抽象化します
  */
-export interface ILineNotifyMessenger {
+export interface IHttpRequestHandler {
     /**
      * HTTP応答オブジェクトを生成します
      * @param status - HTTPステータスコード
      * @param body - レスポンスボディの内容
      * @returns 実行環境に対応したHTTPレスポンスオブジェクト
      */
-    buildHttpResponse(status: number, body: string): FunctionsHttpResponse | LambdaHttpResponse;
+    buildHttpResponse(status: number, body: string): AzureFunctionsHttpResponse | AwsLambdaHttpResponse;
     
     /**
      * リクエストURLからパス部分を取得します

--- a/src/services/httpResponseService.ts
+++ b/src/services/httpResponseService.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { FunctionsHttpResponse, ILineNotifyMessenger, LambdaHttpResponse } from '@interfaces/lineNotifyMessenger';
+import { AzureFunctionsHttpResponse, IHttpRequestHandler, AwsLambdaHttpResponse } from '@interfaces/httpRequestHandler';
 import { inject, injectable } from 'tsyringe';
 
 /**
@@ -8,17 +8,17 @@ import { inject, injectable } from 'tsyringe';
  */
 @injectable()
 export class HttpResponseService {
-    /** HTTPリクエスト/レスポンス処理を担当するメッセンジャー */
-    private messenger: ILineNotifyMessenger;
+    /** HTTPリクエスト/レスポンス処理を担当するハンドラー */
+    private handler: IHttpRequestHandler;
 
     /**
      * HttpResponseServiceのコンストラクタ
-     * @param messenger HTTPリクエスト/レスポンス処理用メッセンジャー
+     * @param handler HTTPリクエスト/レスポンス処理用ハンドラー
      */
     constructor(
-        @inject('ILineNotifyMessenger') messenger: ILineNotifyMessenger,
+        @inject('IHttpRequestHandler') handler: IHttpRequestHandler,
     ) {
-        this.messenger = messenger;
+        this.handler = handler;
     }
 
     /**
@@ -26,8 +26,8 @@ export class HttpResponseService {
      * @param message エラーメッセージ
      * @returns HTTP 401レスポンスオブジェクト
      */
-    httpUnAuthorizedErrorMessage(message: string): LambdaHttpResponse | FunctionsHttpResponse {
-        return this.messenger.buildHttpResponse(401, message);
+    httpUnAuthorizedErrorMessage(message: string): AwsLambdaHttpResponse | AzureFunctionsHttpResponse {
+        return this.handler.buildHttpResponse(401, message);
     }
 
     /**
@@ -35,8 +35,8 @@ export class HttpResponseService {
      * @param message エラーメッセージ
      * @returns HTTP 500レスポンスオブジェクト
      */
-    httpInternalServerErrorMessage(message: string): LambdaHttpResponse | FunctionsHttpResponse {
-        return this.messenger.buildHttpResponse(500, message);
+    httpInternalServerErrorMessage(message: string): AwsLambdaHttpResponse | AzureFunctionsHttpResponse {
+        return this.handler.buildHttpResponse(500, message);
     }
 
     /**
@@ -44,7 +44,7 @@ export class HttpResponseService {
      * @param message 応答メッセージ
      * @returns HTTP 200レスポンスオブジェクト
      */
-    httpOkMessage(message: string): LambdaHttpResponse | FunctionsHttpResponse {
-        return this.messenger.buildHttpResponse(200, message);
+    httpOkMessage(message: string): AwsLambdaHttpResponse | AzureFunctionsHttpResponse {
+        return this.handler.buildHttpResponse(200, message);
     }
 }


### PR DESCRIPTION
This pull request includes significant changes to the codebase to replace the `ILineNotifyMessenger` interface with the `IHttpRequestHandler` interface across various files. The changes aim to standardize the handling of HTTP requests and responses for AWS Lambda and Azure Functions environments. Below are the most important changes:

### Interface and Class Renaming

* `src/interfaces/lineNotifyMessenger.ts` was renamed to `src/interfaces/httpRequestHandler.ts`, and the interface `ILineNotifyMessenger` was replaced with `IHttpRequestHandler`. The corresponding response classes were also renamed (`FunctionsHttpResponse` to `AzureFunctionsHttpResponse` and `LambdaHttpResponse` to `AwsLambdaHttpResponse`). [[1]](diffhunk://#diff-9a875b67f73476c9901782c55748aefec2745532cd4b7236cd42da435678a784L7-R14) [[2]](diffhunk://#diff-9a875b67f73476c9901782c55748aefec2745532cd4b7236cd42da435678a784L28-R35) [[3]](diffhunk://#diff-9a875b67f73476c9901782c55748aefec2745532cd4b7236cd42da435678a784L50-R57)

### Core Application Changes

* In `src/core/lineNotifyMessengerApp.ts`, all references to `ILineNotifyMessenger` were replaced with `IHttpRequestHandler`, and the corresponding methods were updated to use `IHttpRequestHandler` methods. [[1]](diffhunk://#diff-6132a64ed961007a065dcbe608bf1b0d8f85961de69a79f3328d9154f32beba4L3-R3) [[2]](diffhunk://#diff-6132a64ed961007a065dcbe608bf1b0d8f85961de69a79f3328d9154f32beba4L18-R19) [[3]](diffhunk://#diff-6132a64ed961007a065dcbe608bf1b0d8f85961de69a79f3328d9154f32beba4L33-R33) [[4]](diffhunk://#diff-6132a64ed961007a065dcbe608bf1b0d8f85961de69a79f3328d9154f32beba4L42-R81) [[5]](diffhunk://#diff-6132a64ed961007a065dcbe608bf1b0d8f85961de69a79f3328d9154f32beba4L174-R174)

### Handler Class Updates

* `src/core/functionsLineNotifyMessenger.ts` was renamed to `src/handlers/functionsHttpRequestHandler.ts`, and the class `FunctionsLineNotifyMessenger` was replaced with `FunctionsHttpRequestHandler`. The methods were updated to align with the new interface. [[1]](diffhunk://#diff-2494c936da5abf6b324cf9097fe2b3fd088047ada30bdfccbd375bdea02381c1L2-R17) [[2]](diffhunk://#diff-2494c936da5abf6b324cf9097fe2b3fd088047ada30bdfccbd375bdea02381c1L30-R31)
* `src/core/lambdaLineNotifyMessenger.ts` was renamed to `src/handlers/lambdaHttpRequestHandler.ts`, and the class `LambdaLineNotifyMessenger` was replaced with `LambdaHttpRequestHandler`. The methods were similarly updated. [[1]](diffhunk://#diff-0d987ab9b9586558397487041350d1948e96f87e5cac13022c28df4b34e3bc4aL3-R15) [[2]](diffhunk://#diff-0d987ab9b9586558397487041350d1948e96f87e5cac13022c28df4b34e3bc4aL31-R32)

### Request Handler Updates

* In `src/handlers/requestHandler.ts`, the `ILineNotifyMessenger` interface was replaced with `IHttpRequestHandler`, and all methods were updated to use the new interface. [[1]](diffhunk://#diff-e8931586cb9a5eefec37ec8bc15ec608bdb60b59ab8a1d6c5b3bb2f5a44dffb7L3-R30) [[2]](diffhunk://#diff-e8931586cb9a5eefec37ec8bc15ec608bdb60b59ab8a1d6c5b3bb2f5a44dffb7L42-R44) [[3]](diffhunk://#diff-e8931586cb9a5eefec37ec8bc15ec608bdb60b59ab8a1d6c5b3bb2f5a44dffb7L58-R67)

### Documentation Updates

* Updated references in `README.md` and `CONTRIBUTING.md` to reflect the changes in interface and class names, ensuring the documentation is consistent with the codebase. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L7-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R19) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31)