### PR TITLE
Add cloudflare GitHub action

### DIFF
--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -20,19 +20,22 @@ jobs:
         with:
           node-version: 20
           
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.11.2
-          terraform_wrapper: false
-
       - name: Install dependencies
         run: npm install
 
       - name: update config
+        run: npm run wrangler-types
+
+      - name: create wrangler.toml
         run: |
-            npm run update-config 
-            npm run wrangler-types
+            cp wrangler.toml.template wrangler.toml
+            sed -i "s/\$\{\{KV_NAMESPACE_ID\}\}"/${KV_NAMESPACE_ID}/g" wrangler.toml
+            sed -i "s/\$\{\{R2_BUCKET_NAME\}\}"/${R2_BUCKET_NAME}/g" wrangler.toml
+            sed -i "s/\$\{\{SEND_MODE\}\}"/${SEND_MODE}/g" wrangler.toml
+        env:
+            KV_NAMESPACE_ID: ${{ vars.KV_NAMESPACE_ID }}
+            R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}
+            SEND_MODE: ${{ vars.SEND_MODE }}
 
       - name: Publish with Wrangler
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: update config
-        run: npm run wrangler-types
-
       - name: create wrangler.toml
         run: |
             cp wrangler.toml.template wrangler.toml
@@ -36,6 +33,9 @@ jobs:
             KV_NAMESPACE_ID: ${{ vars.KV_NAMESPACE_ID }}
             R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}
             SEND_MODE: ${{ vars.SEND_MODE }}
+
+      - name: wrangler types
+        run: npm run wrangler-types
 
       - name: Publish with Wrangler
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -25,7 +25,7 @@ jobs:
       - name: create wrangler.toml
         run: |
             # 環境変数に基づいてテンプレートを処理
-            cat wrangler.tmp.toml | envsubst > wrangler.toml
+            cat wrangler.toml.template | envsubst > wrangler.toml
         env:
             KV_NAMESPACE_ID: ${{ vars.KV_NAMESPACE_ID }}
             R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -25,10 +25,13 @@ jobs:
 
       - name: create wrangler.toml
         run: |
-            cp wrangler.toml.template wrangler.toml
-            sed -i "s/\\$\\{\\{KV_NAMESPACE_ID\\}\\}/${KV_NAMESPACE_ID}/g" wrangler.toml
-            sed -i "s/\\$\\{\\{R2_BUCKET_NAME\\}\\}/${R2_BUCKET_NAME}/g" wrangler.toml
-            sed -i "s/\\$\\{\\{SEND_MODE\\}\\}/${SEND_MODE}/g" wrangler.toml
+            # 変数をエクスポート
+            export KV_NAMESPACE_ID="${KV_NAMESPACE_ID}"
+            export R2_BUCKET_NAME="${R2_BUCKET_NAME}"
+            export SEND_MODE="${SEND_MODE}"
+            
+            # 環境変数に基づいてテンプレートを処理
+            cat wrangler.toml.template | envsubst > wrangler.toml
         env:
             KV_NAMESPACE_ID: ${{ vars.KV_NAMESPACE_ID }}
             R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -26,10 +26,6 @@ jobs:
         run: |
             # 環境変数に基づいてテンプレートを処理
             cat wrangler.tmp.toml | envsubst > wrangler.toml
-            rm wrangler.tmp.toml
-            
-            # 確認
-            cat wrangler.toml
         env:
             KV_NAMESPACE_ID: ${{ vars.KV_NAMESPACE_ID }}
             R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -45,4 +45,4 @@ jobs:
         with:
           wranglerVersion: '4.3.0'
         env:
-          CLOUDFLARE_API_TOKEN: ${{ vars.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: create wrangler.toml
         run: |
-            cat wrangler.toml.template | sed 's/{{/{/g' | sed 's/}}/}/g' > wrangler.tmp.toml
-            
             # 環境変数に基づいてテンプレートを処理
             cat wrangler.tmp.toml | envsubst > wrangler.toml
             rm wrangler.tmp.toml

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -25,13 +25,13 @@ jobs:
 
       - name: create wrangler.toml
         run: |
-            # 変数をエクスポート
-            export KV_NAMESPACE_ID="${KV_NAMESPACE_ID}"
-            export R2_BUCKET_NAME="${R2_BUCKET_NAME}"
-            export SEND_MODE="${SEND_MODE}"
+            cat wrangler.toml.template | sed 's/\${{/\${/g' | sed 's/}}/}/g' > wrangler.tmp.toml
             
             # 環境変数に基づいてテンプレートを処理
-            cat wrangler.toml.template | envsubst > wrangler.toml
+            cat wrangler.tmp.toml | envsubst > wrangler.toml
+            rm wrangler.tmp.toml
+            
+            # 確認
             cat wrangler.toml
         env:
             KV_NAMESPACE_ID: ${{ vars.KV_NAMESPACE_ID }}

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -32,6 +32,7 @@ jobs:
             
             # 環境変数に基づいてテンプレートを処理
             cat wrangler.toml.template | envsubst > wrangler.toml
+            cat wrangler.toml
         env:
             KV_NAMESPACE_ID: ${{ vars.KV_NAMESPACE_ID }}
             R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: create wrangler.toml
         run: |
-            cat wrangler.toml.template | sed 's/\$\{\{/\$\{/g' | sed 's/\}\}/\}/g' > wrangler.tmp.toml
+            cat wrangler.toml.template | sed 's/\\$\\{\\{/\\$\\{/g' | sed 's/\\}\\}/\\}/g' > wrangler.tmp.toml
             
             # 環境変数に基づいてテンプレートを処理
             cat wrangler.tmp.toml | envsubst > wrangler.toml

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -19,6 +19,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.11.2
+          terraform_wrapper: false
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -9,7 +9,6 @@ jobs:
 
     permissions:
       contents: read
-      id-token: write  # OIDC経由の認証用
       
     steps:
       - name: Checkout repository
@@ -45,8 +44,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           wranglerVersion: '4.3.0'
-          postCommands: |
-            echo "Deploying with GitHub OIDC"
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          # API Tokenを使用せず、GitHub ActionsのOIDCを使用
+          CLOUDFLARE_API_TOKEN: ${{ vars.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Publish with Wrangler
         uses: cloudflare/wrangler-action@v3
         with:
-          wranglerVersion: '3'
+          wranglerVersion: '4.3.0'
           postCommands: |
             echo "Deploying with GitHub OIDC"
         env:

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: create wrangler.toml
         run: |
-            cat wrangler.toml.template | sed 's/\\$\\{\\{/\\$\\{/g' | sed 's/\\}\\}/\\}/g' > wrangler.tmp.toml
+            cat wrangler.toml.template | sed 's/{{/{/g' | sed 's/}}/}/g' > wrangler.tmp.toml
             
             # 環境変数に基づいてテンプレートを処理
             cat wrangler.tmp.toml | envsubst > wrangler.toml

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: create wrangler.toml
         run: |
-            cat wrangler.toml.template | sed 's/\${{/\${/g' | sed 's/}}/}/g' > wrangler.tmp.toml
+            cat wrangler.toml.template | sed 's/\$\{\{/\$\{/g' | sed 's/\}\}/\}/g' > wrangler.tmp.toml
             
             # 環境変数に基づいてテンプレートを処理
             cat wrangler.tmp.toml | envsubst > wrangler.toml

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -1,4 +1,4 @@
-name: Deploy Cloudflare Workers
+name: Deploy Cloudflare Worker
 
 on:
     workflow_dispatch:

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -1,4 +1,4 @@
-name: Deploy Cloudflare Worker
+name: Deploy Cloudflare Workers
 
 on:
     workflow_dispatch:
@@ -44,5 +44,4 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           wranglerVersion: '4.3.0'
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -26,9 +26,9 @@ jobs:
       - name: create wrangler.toml
         run: |
             cp wrangler.toml.template wrangler.toml
-            sed -i "s/\$\{\{KV_NAMESPACE_ID\}\}"/${KV_NAMESPACE_ID}/g" wrangler.toml
-            sed -i "s/\$\{\{R2_BUCKET_NAME\}\}"/${R2_BUCKET_NAME}/g" wrangler.toml
-            sed -i "s/\$\{\{SEND_MODE\}\}"/${SEND_MODE}/g" wrangler.toml
+            sed -i "s/\\$\\{\\{KV_NAMESPACE_ID\\}\\}/${KV_NAMESPACE_ID}/g" wrangler.toml
+            sed -i "s/\\$\\{\\{R2_BUCKET_NAME\\}\\}/${R2_BUCKET_NAME}/g" wrangler.toml
+            sed -i "s/\\$\\{\\{SEND_MODE\\}\\}/${SEND_MODE}/g" wrangler.toml
         env:
             KV_NAMESPACE_ID: ${{ vars.KV_NAMESPACE_ID }}
             R2_BUCKET_NAME: ${{ vars.R2_BUCKET_NAME }}

--- a/bin/update-dev-vars.js
+++ b/bin/update-dev-vars.js
@@ -18,9 +18,9 @@ fs.writeFileSync('.dev.vars', devVarsContent);
 // wrangler.toml.templateファイルを読み込み、${{PROD_R2_BUCKET_NAME}}"を置換
 const wranglerTomlTemplate = fs.readFileSync('wrangler.toml.template').toString();
 const wranglerToml = wranglerTomlTemplate
-  .replace('${{R2_BUCKET_NAME}}', terraformOutput.r2_bucket_name.value)
-  .replace('${{KV_NAMESPACE_ID}}', terraformOutput.kv_namespace_id.value)
-  .replace('${{SEND_MODE}}', process.env.SEND_MODE || "group");
+  .replace('${R2_BUCKET_NAME}', terraformOutput.r2_bucket_name.value)
+  .replace('${KV_NAMESPACE_ID}', terraformOutput.kv_namespace_id.value)
+  .replace('${SEND_MODE}', process.env.SEND_MODE || "group");
 
   fs.writeFileSync('wrangler.toml', wranglerToml);
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,5 @@
+interface Env {
+    // シークレットとして使いたい環境変数
+    LINE_CHANNEL_ACCESS_TOKEN: string;
+    AUTHORIZATION_TOKEN: string;
+}

--- a/wrangler.toml.template
+++ b/wrangler.toml.template
@@ -8,14 +8,15 @@ command = "tsc"
 
 [[kv_namespaces]]
 binding = "GROUPS"
-id = "${{KV_NAMESPACE_ID}}"
+id = "${KV_NAMESPACE_ID}"
 
 [[r2_buckets]]
 binding = "IMAGES"
-bucket_name = "${{R2_BUCKET_NAME}}"
+bucket_name = "${R2_BUCKET_NAME}"
 
 [vars]
-SEND_MODE = "${{SEND_MODE}}"
+SEND_MODE = "${SEND_MODE}"
 
 [observability.logs]
 enabled = true
+


### PR DESCRIPTION
This pull request focuses on updating the deployment workflow for Cloudflare and making template adjustments in the configuration file. The most important changes include modifying the `deploy-to-cloudflare.yml` workflow file to improve the deployment process and updating the `wrangler.toml.template` file to correct environment variable syntax.

Improvements to deployment workflow:

* [`.github/workflows/deploy-to-cloudflare.yml`](diffhunk://#diff-b890f045dad22a3d4ad74eb0ecfbe5865e6345741cf67b17f6fcf25a9df523f4L12): Removed the `id-token` permission to streamline authentication.
* [`.github/workflows/deploy-to-cloudflare.yml`](diffhunk://#diff-b890f045dad22a3d4ad74eb0ecfbe5865e6345741cf67b17f6fcf25a9df523f4L26-R41): Replaced the `update config` step with `create wrangler.toml` to process the template based on environment variables, and added environment variables for the template processing.
* [`.github/workflows/deploy-to-cloudflare.yml`](diffhunk://#diff-b890f045dad22a3d4ad74eb0ecfbe5865e6345741cf67b17f6fcf25a9df523f4L26-R41): Updated the `Publish with Wrangler` step to use a specific API token instead of GitHub OIDC.

Template adjustments:

* [`wrangler.toml.template`](diffhunk://#diff-af2b3d04968b7a4a748dd2ec02e7d5fb942f94407b052641fabd89dc9e478398L11-R22): Corrected the syntax for environment variables by removing the extra braces around variable names.