### PR TITLE
45 create aws deploy workflow

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -1,0 +1,43 @@
+name: Deploy AWS Lambda
+
+on:
+    workflow_dispatch:
+
+jobs:
+    job:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+            id-token: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Install Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Install AWS CDK
+              run: npm install -g aws-cdk
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                aws-region: ${{ vars.AWS_REGION }}
+                role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+
+            - name: Deploy to AWS Lambda
+              run: |
+                npm run build
+                npm run deploy
+              env:
+                LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
+                AUTHORIZATION_TOKEN: ${{ secrets.AUTHORIZATION_TOKEN }}
+                APP_SUFFIX: ${{ vars.APP_SUFFIX }}
+                SEND_MODE: ${{ vars.SEND_MODE }}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ AWS LambdaまたはAzure Functionsをデプロイ先として使用します。
    bashの場合
 
    ```bash
-   export LINE_CHANNEL_ACCESS='YOUR_CHANNEL_ACCESS_TOKEN'
+   export LINE_CHANNEL_ACCESS_TOKEN='YOUR_CHANNEL_ACCESS_TOKEN'
    ```
 
    PowerShellの場合

--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ AWS LambdaまたはAzure Functionsをデプロイ先として使用します。
 
    この場合、`npm run deploy`を実行すると、スタック名が`LineNotifyMessengerS3Stack-xxxx`と`LineNotifyMessengerLambdaStack-xxxx`になります。
 
+GitHub Actionsでデプロイする場合は、以下のようにします。
+
+1. AWS CDKのデプロイに必要な環境変数をリポジトリのSecretに設定します。
+   - `LINE_CHANNEL_ACCESS_TOKEN`: LINE Messaging APIのチャンネルアクセストークン
+   - `AUTHORIZATION_TOKEN`: LINE NotifyのAuthorizationヘッダの値
+   - `AWS_ROLE_ARN`: デプロイ時に使用するIAMロールのARN。[こちら](https://aws.amazon.com/jp/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/)を参考にIAMロールを作成して、そのARNを設定します。
+2. AWS CDKのデプロイに必要な環境変数をリポジトリの環境変数に設定します。
+   - `AWS_REGION`: AWSリージョン
+   - `SEND_MODE`: 送信モードとして`group`を設定します
+   - `APP_SUFFIX`: スタック名にサフィックスをつける場合は、任意のサフィックスを設定します
+3. `Deploy AWS Lambda`ワークフローをGitHubのページから手動で実行します。[GitHubの公式ドキュメント](https://docs.github.com/ja/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)を参照して下さい。
+
 ### Azure
 
 1. 以下のボタンを押して環境を構築します。LINE_CHANNEL_ACCESS_TOKENとAUTHORIZATION_TOKENには、LINE Messaging APIのチャンネルアクセストークンと、これまで使っていたLINE NotifyのAuthorizationヘッダの値を設定します。
@@ -130,7 +142,7 @@ AWS LambdaまたはAzure Functionsをデプロイ先として使用します。
 
 4. 同じくForkしたリポジトリのActionsのVariables `FUNCTION_NAME` に、Azure Functionsの関数名を登録します。
 
-5. `Build and deploy Node.js project to Azure Function App`ワークフローをGitHubのページから手動で実行します。[GitHubの公式ドキュメント](https://docs.github.com/ja/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)を参照して下さい。
+5. `Build and deploy Node.js project to Azure Function App`ワークフローをGitHubのページから手動で実行します。
 
 ### cloudflare
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying to AWS Lambda and updates the documentation to reflect these changes. The most important changes include the creation of the deployment workflow and updates to the README file to guide users on how to use the new workflow.

### New GitHub Actions Workflow:
* [`.github/workflows/deploy-to-aws.yml`](diffhunk://#diff-045803c750db41d5cc9f6492c00fa04245b9d5381346a4bcf1c168919233e8e1R1-R43): Added a new workflow for deploying to AWS Lambda, which includes steps for checking out the repository, setting up Node.js, installing dependencies, configuring AWS credentials, and running the deployment.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R77): Corrected the environment variable name for the LINE channel access token.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R121-R132): Added instructions for deploying using GitHub Actions, including setting up necessary secrets and environment variables, and running the workflow manually. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R121-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R145)