### PR TITLE
54 directory structure for azure funcitons

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,20 @@ GitHub Actionsでデプロイする場合は、環境を構築したら以下を
 
 4. `Build and deploy Node.js project to Azure Function App`ワークフローをGitHubのページから手動で実行します。
 
+Visual Studio Codeを使用している場合は、Azure Functionsの拡張機能でのデプロイも可能です。
+
+1. Azure Functionsの拡張機能をインストールします
+
+2. Azure Functionsの拡張機能を開き、Functionsを右クリックして「Deploy to Function App」を選択します
+
+3. コマンドパレットから「Azure Functions: Deploy to Function App」を選択します
+
+4. デプロイターゲットのディレクトリの指定で、`functions`ディレクトリを選択します
+
+5. デプロイ先のサブスクリプションを選択します
+
+6. 先ほど作成したFunction Appを選択します
+
 ### cloudflare
 
 1. LINE_CHANNEL_ACCESS_TOKENとAUTHORIZATION_TOKENとSEND_MODを環境変数に設定します。

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -14,7 +14,6 @@
       },
       "devDependencies": {
         "@azure/functions": "^4.6.1",
-        "@azure/storage-blob": "^12.26.0",
         "@types/node": "18.x",
         "azure-functions-core-tools": "^4.x",
         "esbuild": "^0.25.0",
@@ -67,7 +66,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.2.0.tgz",
       "integrity": "sha512-1kW8ZhN0CfbNOG6C688z5uh2yrzALE7dDXHiR9dY4vt+EbhGZQSbjDa5bQd2rf3X2pdWMsXbqbArxUyeNdvtmg==",
-      "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-client": "^1.3.0",
@@ -81,7 +79,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
       "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
-      "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.2.0",
@@ -205,7 +202,6 @@
       "version": "12.26.0",
       "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.26.0.tgz",
       "integrity": "sha512-SriLPKezypIsiZ+TtlFfE46uuBIap2HeaQVS78e1P7rz5OSbq0rsd52WE1mC5f7vAeLiXqv7I7oRhL3WFZEw3Q==",
-      "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.4.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@azure/functions": "^4.6.1",
-    "@azure/storage-blob": "^12.26.0",
     "@types/node": "18.x",
     "azure-functions-core-tools": "^4.x",
     "esbuild": "^0.25.0",


### PR DESCRIPTION
This pull request includes updates to the deployment documentation and modifications to the `package-lock.json` and `package.json` files to remove the `@azure/storage-blob` dependency.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R182-R195): Added instructions for deploying using the Azure Functions extension in Visual Studio Code.

Dependency updates:

* [`functions/package-lock.json`](diffhunk://#diff-4344b694eb816225873849f96a11303de5fb9cf3b95c349bae6f93df89a426bbL17): Removed the `@azure/storage-blob` dependency and its associated metadata. [[1]](diffhunk://#diff-4344b694eb816225873849f96a11303de5fb9cf3b95c349bae6f93df89a426bbL17) [[2]](diffhunk://#diff-4344b694eb816225873849f96a11303de5fb9cf3b95c349bae6f93df89a426bbL70) [[3]](diffhunk://#diff-4344b694eb816225873849f96a11303de5fb9cf3b95c349bae6f93df89a426bbL84) [[4]](diffhunk://#diff-4344b694eb816225873849f96a11303de5fb9cf3b95c349bae6f93df89a426bbL208)
* [`functions/package.json`](diffhunk://#diff-47a4c468f7490979e1df8b5577fd4433613c9c50f054fc38426a0dcddb214436L22): Removed the `@azure/storage-blob` dependency from the `devDependencies` section.


close #54